### PR TITLE
Fix RT bugs; add -quiet; better testing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension Devel::Hide.
 
+0.0011      2020-02-12
+
+   - Fix https://rt.cpan.org/Public/Bug/Display.html?id=120220
+   - Fix https://rt.cpan.org/Public/Bug/Display.html?id=120221
+   - Add -quiet option to suppress some notices
+
 0.0010      2018-06-15 09:12:54-07:00 America/Los_Angeles
 
    - Makefile.PL: better prereqs declaration

--- a/MANIFEST
+++ b/MANIFEST
@@ -10,11 +10,13 @@ t/004env.t
 t/005lib.t
 t/006before.t
 t/050child-processes.t                   Tests -from:children
-t/child.pl
+t/child.pl                                 script run from t/050child-processes.t
 t/090pod.t                               Tests POD for errors
 t/098pod-coverage.t                      Tests for POD coverage
+t/quiet.t                                Test that -quiet suppresses (some) warnings
+t/too-late-quiet.t                       Test that -quiet doesn't suppress warnings about not hiding stuff
 
-t/P.pm                                   Dummy module used in tests (002-006, 050)
+t/P.pm                                   Dummy module used in tests
 t/Q.pm                                   "
 t/R.pm                                   "
 

--- a/lib/Devel/Hide.pm
+++ b/lib/Devel/Hide.pm
@@ -4,7 +4,7 @@ use 5.006001;
 use strict;
 use warnings;
 
-our $VERSION = '0.0010';
+our $VERSION = '0.0011';
 
 # blech! package variables
 use vars qw( @HIDDEN $VERBOSE );
@@ -392,6 +392,8 @@ with contributions from David Cantrell E<lt>dcantrell@cpan.orgE<gt>
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2005-2007, 2018 by Adriano R. Ferreira
+
+Some parts copyright (C) 2020 by David Cantrell
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/lib/Devel/Hide.pm
+++ b/lib/Devel/Hide.pm
@@ -67,7 +67,7 @@ BEGIN {
 }
 
 # Pushes a list to the set of hidden modules/filenames
-# warns about the modules which could not be hidden
+# warns about the modules which could not be hidden (always)
 # and about the ones that were successfully hidden (if $VERBOSE)
 #
 # It works as a batch producing warning messages
@@ -86,7 +86,7 @@ sub _push_hidden {
             $IS_HIDDEN{$_}++;
         }
     }
-    if ( $VERBOSE && @too_late ) {
+    if ( @too_late ) {
         warn __PACKAGE__, ': Too late to hide ', join( ', ', @too_late ), "\n";
     }
     if ( $VERBOSE && keys %IS_HIDDEN ) {
@@ -113,37 +113,10 @@ BEGIN {
 
 }
 
-# works for perl 5.8.0, uses in-core files
-sub _scalar_as_io8 {
-    open my $io, '<', \$_[0]
-        or die $!;    # this should not happen (perl 5.8 should support this)
-    return $io;
-}
-
-# works for perl >= 5.6.1, uses File::Temp
-sub _scalar_as_io6 {
-    my $scalar = shift;
-    require File::Temp;
-    my $io = File::Temp::tempfile();
-    print {$io} $scalar;
-    seek $io, 0, 0;    # rewind the handle
-    return $io;
-}
-
-BEGIN {
-
-    *_scalar_as_io = ( $] >= 5.008 ) ? \&_scalar_as_io8 : \&_scalar_as_io6;
-
-    # _scalar_as_io is one of the two sub's above
-
-}
-
 sub _dont_load {
     my $filename = shift;
-    my $oops;
     my $hidden_by = $VERBOSE ? 'hidden' : 'hidden by ' . __PACKAGE__;
-    $oops = qq{die "Can't locate $filename ($hidden_by)\n"};
-    return _scalar_as_io($oops);
+    die "Can't locate $filename in \@INC ($hidden_by)\n";
 }
 
 sub _is_hidden {
@@ -192,21 +165,31 @@ sub _append_to_perl5opt {
 
     $ENV{PERL5OPT} = join( ' ',
         defined($ENV{PERL5OPT}) ? $ENV{PERL5OPT} : (),
-        'MDevel::Hide=' . join(',', @_)
+        '-MDevel::Hide=' . join(',', @_)
     );
 
 }
 
 sub import {
     shift;
-    if( @_ && $_[0] eq '-from:children' ) {
-        $HIDE_FROM{children} = 1;
+    while(@_ && $_[0] =~ /^-/) {
+        if( $_[0] eq '-from:children' ) {
+            $HIDE_FROM{children} = 1;
+        } elsif( $_[0] eq '-quiet' ) {
+            $VERBOSE = 0;
+            $HIDE_FROM{children_quietly} = 1;
+        } else {
+            die("Devel::Hide: don't recognize $_[0]\n");
+        }
         shift;
     }
     if (@_) {
         _push_hidden(@_);
         if ($HIDE_FROM{children}) {
-            _append_to_perl5opt(@_);
+            _append_to_perl5opt(
+                ($HIDE_FROM{children_quietly} ? '-quiet' : ()),
+                @_
+            );
         }
     }
 
@@ -277,7 +260,7 @@ specified files/modules are installed or not).
 
 They I<die> with a message like:
 
-    Can't locate Module/ToHide.pm (hidden)
+    Can't locate Module/ToHide.pm in @INC (hidden)
 
 The original intent of this module is to allow Perl developers
 to test for alternative behavior when some modules are not
@@ -330,12 +313,25 @@ import()
 
 =back
 
-Optionally, you can propagate the list of hidden modules to your
-process' child processes, by passing '-from:children' as the
-first option when you use() this module. This works by populating
+Optionally, you can provide some arguments *before* the
+list of modules:
+
+=over
+
+=item -from:children
+
+propagate the list of hidden modules to your
+process' child processes. This works by populating
 C<PERL5OPT>, and is incompatible with Taint mode, as
 explained in L<perlrun>.
 
+=item -quiet
+
+suppresses diagnostic output. You will still get told about
+errors. This is passed to child processes if -from:children
+is in effect.
+
+=back
 
 =head2 CAVEATS
 

--- a/t/002basic.t
+++ b/t/002basic.t
@@ -1,18 +1,38 @@
-
 use strict;
-use Test::More tests => 5;
+use warnings;
+use Test::More tests => 14;
 
-use_ok('lib', 't');
+use lib 't';
 
-# this script tests the standard use statement
+my @expected_warnings;
+BEGIN {
+    push @expected_warnings,
+        'Devel::Hide hides Q.pm, R.pm';
+    $SIG{__WARN__} = sub {
+        ok($_[0] eq shift(@expected_warnings)."\n",
+            "got expected warning: $_[0]");
+    }
+}
+END { ok(!@expected_warnings, "got all expected warnings") }
 
-use_ok('Devel::Hide', 'Q.pm', 'R');
+use Devel::Hide qw(Q.pm R);
 
-eval { require P }; 
-ok(!$@, "P was loaded (as it should)");
-
-eval { require Q }; 
-like($@, qr/^Can't locate Q\.pm/, "Q not found (as it should)");
-
-eval { require R }; 
-like($@, qr/^Can't locate R\.pm/, "R not found (as it should)");
+# do this twice, see https://rt.cpan.org/Ticket/Display.html?id=120220
+foreach my $pass (1, 2) {
+    eval { require P }; 
+    ok(!$@, "nothing moaned about loading P".
+        ($pass == 2 ? ' again' : ''));
+    ok(exists($INC{"P.pm"}), "P is loaded");
+    
+    eval { require Q }; 
+    like($@, qr/^Can't locate Q\.pm in \@INC/,
+        "correctly moaned about loading Q".
+        ($pass == 2 ? ' again' : ''));
+    ok(!exists($INC{"Q.pm"}), "correctly didn't load Q");
+    
+    eval { require R }; 
+    like($@, qr/^Can't locate R\.pm in \@INC/,
+        "correctly moaned about loading Q".
+        ($pass == 2 ? ' again' : ''));
+    ok(!exists($INC{"R.pm"}), "correctly didn't load R");
+}

--- a/t/050child-processes.t
+++ b/t/050child-processes.t
@@ -1,11 +1,19 @@
-
 use strict;
-use Devel::Hide qw(-from:children Q.pm R);
+use warnings;
+use Devel::Hide qw(-quiet -from:children Q.pm R);
 
 # Mlib=t is to get around 'use lib' etc being annoying
 
-$ENV{PERL5OPT} = 'Mlib=t '.$ENV{PERL5OPT};
+$ENV{PERL5OPT} = '-Mblib '.$ENV{PERL5OPT}
+    if($INC{'blib.pm'});
+$ENV{PERL5OPT} = '-Mlib=t '.$ENV{PERL5OPT};
 
-my $ans = system( $^X, 't/child.pl' );
+# run this script and tell it to:
+#  try to load P, Q and R;
+#  expect only P to succeed;
+# moan about Q and R
+my $ans = system( $^X, qw(
+    t/child.pl try:PQR succeed:P moan:QR
+) );
 
 exit( $ans >> 8 );

--- a/t/child.pl
+++ b/t/child.pl
@@ -1,15 +1,31 @@
-
-# invoked by "t/050child-processes.t"
-
 use strict;
-use Test::More tests => 4;
+use warnings;
+
+my $warnings;
+BEGIN { $SIG{__WARN__} = sub { $warnings++ } }
+my %args;
+BEGIN {
+    %args = map {
+         my($k, $v) = split(/:/, $_);
+        $k => [split(//, $v)]
+    } @ARGV;
+}
+
+# the command line had -MDevel::Hide=-quiet so
+# the warning this generates should be suppressed
+use Devel::Hide 'Q';
+
+use Test::More tests => 2 + @{$args{try}};
 
 ok($ENV{PERL5OPT} =~ /\bMlib=t\b/, "PERL5OPT is added to, not overwritten: $ENV{PERL5OPT}");
-eval { require P }; 
-ok(!$@, "P was loaded (as it should)");
 
-eval { require Q }; 
-like($@, qr/^Can't locate Q\.pm/, "Q not found (as it should)");
+foreach my $try (@{$args{try}}) {
+    eval "require $try";
+    if(!grep { $_ eq $try } @{$args{moan}}) {
+        ok(!$@, "nothing moaned about loading $try");
+    } else {
+        like($@, qr/^Can't locate $try\.pm/, "correctly moaned about loading $try");
+    }
+}
 
-eval { require R }; 
-like($@, qr/^Can't locate R\.pm/, "R not found (as it should)");
+ok(!$warnings, "suppressed warnings");

--- a/t/quiet.t
+++ b/t/quiet.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use lib 't';
+
+my $warnings;
+BEGIN { $SIG{__WARN__} = sub { $warnings++ } }
+END { ok(!$warnings, "suppressed warnings"); }
+
+use Devel::Hide qw(-quiet Q);
+
+eval { require Q }; 
+like($@, qr/^Can't locate Q\.pm in \@INC/,
+    "correctly moaned about loading Q");

--- a/t/too-late-quiet.t
+++ b/t/too-late-quiet.t
@@ -1,14 +1,13 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 6;
 
 use lib 't';
 
 my @expected_warnings;
 BEGIN {
     push @expected_warnings,
-        'Devel::Hide: Too late to hide P.pm',
-        'Devel::Hide hides Q.pm';
+        'Devel::Hide: Too late to hide P.pm';
     $SIG{__WARN__} = sub {
         ok($_[0] eq shift(@expected_warnings)."\n",
             "got expected warning: $_[0]");
@@ -17,7 +16,9 @@ BEGIN {
 END { ok(!@expected_warnings, "got all expected warnings") }
 
 use_ok('P'); # loads P
-use_ok('Devel::Hide', 'P', 'Q'); # too late to hide P
+
+# too late to hide P. Q will be hidden, but not mentioned
+use_ok('Devel::Hide', '-quiet', 'P', 'Q');
 
 eval { require P }; 
 ok(!$@, "P was loaded (as it should)");


### PR DESCRIPTION
* Fix https://rt.cpan.org/Public/Bug/Display.html?id=120220
  also add tests to make sure that modules really aren't loaded
  when hidden, not just that Devel::Hide moans about them, and
  that they aren't loaded even if you try to load them again.
* Fix https://rt.cpan.org/Public/Bug/Display.html?id=120221
* Add a -quiet option that suppresses warnings that Devel::Hide is
  going to hide a module. You'll still get warnings if you try to
  hide a module too late.
* That new option propagates into chidl processes if
  -from:children is enabled.
* Add tests that the correct warnings are issued.