### PR TITLE
bump Test::More prereq

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,7 @@ my %write_makefile_args = (
         'prereqs'        => {
             test => {
                 requires => {
-                    'Test::More' => 0,
+                    'Test::More' => 0.82,
                 },
             },
             develop => {


### PR DESCRIPTION
Test suite fails with older versions of Test::More:

```
PERL_DL_NONLAZY=1 "/opt/perl/5.10.0/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/001use................# Testing Devel::Hide 0.0013, Perl 5.010000, /opt/perl/5.10.0/bin/perl
ok
t/002basic..............ok
t/003user...............ok
t/004env................ok
t/005lib................ok
t/006before.............ok
t/050child-processes....ok
t/090pod................skipped
        all skipped: Test::Pod 1.18 required for testing POD
t/098pod-coverage.......skipped
        all skipped: Test::Pod::Coverage 1.04 required for testing POD coverage
t/lexically.............Undefined subroutine &main::note called at t/lexically.t line 31.
# Looks like you planned 9 tests but only ran 3.
# Looks like your test died just after 3.
dubious
	Test returned status 255 (wstat 65280, 0xff00)
DIED. FAILED tests 4-9
	Failed 6/9 tests, 33.33% okay
t/quiet.................ok
t/too-late-quiet........ok
Failed Test   Stat Wstat Total Fail  List of Failed
-------------------------------------------------------------------------------
t/lexically.t  255 65280     9   12  4-9
2 tests skipped.
Failed 1/12 test scripts. 6/58 subtests failed.
Files=12, Tests=58,  0 wallclock secs ( 0.11 cusr +  0.01 csys =  0.12 CPU)
Failed 1/12 test programs. 6/58 subtests failed.
make: *** [Makefile:862: test_dynamic] Error 255
-> FAIL Installing Devel::Hide failed. See /home/cip/.cpanm/work/1619491670.134/build.log for details. Retry with --force to force install it.
```

note was added in 0.81_01, according to https://metacpan.org/changes/distribution/Test-Simple#L1380 and the first prod version after that was 0.82.  I wasn't able to get 0.82 to install but was able to test this with 0.88.